### PR TITLE
bug fix in coverage score; del consistency score when shifts < min_shifts

### DIFF
--- a/clean_up/master.py
+++ b/clean_up/master.py
@@ -10,7 +10,7 @@ from clemcore.clemgame import GameSpec, GameMaster, GameBenchmark, Player, Dialo
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_SUCCESS, METRIC_LOSE, BENCH_SCORE
 # from clemcore.utils import file_utils, string_utils
 from resources.grids.game_grid import GameGrid
-from resources.utils.metrics import MetricPreparer, MetricCalculator, END_DISTANCE_SUM, EXPECTED_DISTANCE_SUM, MOVES, INIT_STATES, END_STATES, PLAYERS, ingredients_registry, sub_metrics_registry #, validate
+from resources.utils.metrics import MetricPreparer, MetricCalculator, END_DISTANCE_SUM, EXPECTED_DISTANCE_SUM, MOVES, INIT_STATES, END_STATES, ingredients_registry, sub_metrics_registry #, validate
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +290,7 @@ class CleanUpMaster(DialogueGameMaster):
             # log all the necessary metrics to `interaction.json`
             self.log_key(key, val)
             # not display some of the ingredients in transcript
-            if key not in [MOVES, INIT_STATES, END_STATES, PLAYERS]:
+            if key not in [MOVES, INIT_STATES, END_STATES]:
                 ingredients_string += f"* {key}: {float(val):.2f}\n"
 
         lose = not self.success

--- a/clean_up/master.py
+++ b/clean_up/master.py
@@ -10,7 +10,7 @@ from clemcore.clemgame import GameSpec, GameMaster, GameBenchmark, Player, Dialo
 from clemcore.clemgame.metrics import METRIC_ABORTED, METRIC_SUCCESS, METRIC_LOSE, BENCH_SCORE
 # from clemcore.utils import file_utils, string_utils
 from resources.grids.game_grid import GameGrid
-from resources.utils.metrics import MetricPreparer, MetricCalculator, END_DISTANCE_SUM, EXPECTED_DISTANCE_SUM, MOVES, INIT_STATES, END_STATES, ingredients_registry, sub_metrics_registry #, validate
+from resources.utils.metrics import MetricPreparer, MetricCalculator, END_DISTANCE_SUM, EXPECTED_DISTANCE_SUM, MOVES, INIT_STATES, END_STATES, PLAYERS, ingredients_registry, sub_metrics_registry #, validate
 
 logger = logging.getLogger(__name__)
 
@@ -290,7 +290,7 @@ class CleanUpMaster(DialogueGameMaster):
             # log all the necessary metrics to `interaction.json`
             self.log_key(key, val)
             # not display some of the ingredients in transcript
-            if key not in [MOVES, INIT_STATES, END_STATES]:
+            if key not in [MOVES, INIT_STATES, END_STATES, PLAYERS]:
                 ingredients_string += f"* {key}: {float(val):.2f}\n"
 
         lose = not self.success
@@ -341,6 +341,8 @@ class CleanUpScorer(GameScorer):
 
         ingredients = {}
         for key in ingredients_registry:
+            if key not in episode_interactions:
+                logger.warning(f"Missing Key: Key {key} should be in episode interactions. ")            
             ingredients[key] = episode_interactions[key]
         
         metrics_calculator = MetricCalculator(ingredients)

--- a/clean_up/master.py
+++ b/clean_up/master.py
@@ -290,7 +290,8 @@ class CleanUpMaster(DialogueGameMaster):
             # log all the necessary metrics to `interaction.json`
             self.log_key(key, val)
             # not display some of the ingredients in transcript
-            if key not in [MOVES, INIT_STATES, END_STATES]:
+            # if key not in [MOVES, INIT_STATES, END_STATES]:
+            if key not in [INIT_STATES, END_STATES]:
                 ingredients_string += f"* {key}: {float(val):.2f}\n"
 
         lose = not self.success
@@ -312,7 +313,7 @@ class CleanUpMaster(DialogueGameMaster):
         # ----------------------------------------------------------
         # dev: also compute sub-metrics and bench score to show on transcript
         metrics_calculator = MetricCalculator(ingredients)
-        sub_metrics, bench_score = metrics_calculator.compute_metrics()
+        sub_metrics, bench_score, temp_log  = metrics_calculator.compute_metrics()
 
         bench_score_string = f"* {BENCH_SCORE}: {float(bench_score):.2f}\n"
 
@@ -320,7 +321,11 @@ class CleanUpMaster(DialogueGameMaster):
         for key, val in sub_metrics.items(): 
             sub_metrics_string += f"* {key}: {float(val):.2f}\n"    
 
-        self.log_to_self('dev:game_finished', f"{bench_score_string}\n-------\n{sub_metrics_string}")
+        temp_log_string = ""
+        for key, val in temp_log.items(): 
+            temp_log_string += f"* {key}: {float(val):.2f}\n"
+
+        self.log_to_self('dev:game_finished', f"{bench_score_string}\n-------\n{sub_metrics_string}\n-------\n{temp_log_string}")
         # ----------------------------------------------------------
 
 class CleanUpScorer(GameScorer):
@@ -346,12 +351,15 @@ class CleanUpScorer(GameScorer):
             ingredients[key] = episode_interactions[key]
         
         metrics_calculator = MetricCalculator(ingredients)
-        sub_metrics, bench_score = metrics_calculator.compute_metrics()        
+        sub_metrics, bench_score, temp_log = metrics_calculator.compute_metrics()        
         # validate(sub_metrics_registry, sub_metrics, self.__class__.__name__)
 
         # log sub-metrics
         for key in sub_metrics:
             self.log_episode_score(key, sub_metrics[key])
+
+        for key in temp_log: 
+            self.log_episode_score(key, temp_log[key])
 
         # log the bench score
         if episode_interactions[METRIC_SUCCESS]:

--- a/clean_up/resources/utils/metrics.py
+++ b/clean_up/resources/utils/metrics.py
@@ -53,7 +53,8 @@ class MetricPreparer:
             INIT_STATES: self.get_states(),
             END_STATES: lambda: self.get_states(),
             SHIFTS: lambda: self.compute_shifts(),
-            MAX_SHIFTS: gm.max_rounds * 2,
+            # MAX_SHIFTS: gm.max_rounds * 2,
+            MAX_SHIFTS: (len(player_1.grid.get_objects()) - 1) * 2,
             MIN_SHIFTS: len(player_1.grid.get_objects()) - 1,
             END_DISTANCE_SUM: lambda: self.player_1.grid.distance_sum(self.player_2.grid), 
             INIT_DISTANCE_SUM: self.gm.initial_distance, 
@@ -198,4 +199,7 @@ class MetricCalculator:
 
         sub_metrics[PENALTY_SCORE] = penalty_score
 
-        return sub_metrics, bench_score
+        # overwrite MAX_SHIFT for existing interactions.json file
+        self.ingredients[MAX_SHIFTS] = self.ingredients[MIN_SHIFTS] * 2 
+
+        return sub_metrics, bench_score, self.ingredients

--- a/clean_up/resources/utils/metrics.py
+++ b/clean_up/resources/utils/metrics.py
@@ -63,7 +63,6 @@ class MetricPreparer:
             ROUNDS: lambda: gm.current_round,
             MAX_ROUNDS: gm.max_rounds,
             OBJECT_COUNT: len(player_1.grid.get_objects()),
-            PLAYERS: [player_1.name, player_2.name]
         }
 
         # validate(ingredients_registry, self.ingredients, self.__class__.__name__)

--- a/clean_up/resources/utils/metrics.py
+++ b/clean_up/resources/utils/metrics.py
@@ -19,12 +19,11 @@ MAX_PENALTIES = "Max Penalties"
 OBJECT_COUNT = "Object Count"
 ROUNDS = "Rounds"
 MAX_ROUNDS = "Max Rounds"
-PLAYERS = "Players"
 ingredients_registry = [MOVES, INIT_STATES, END_STATES,
                         SHIFTS, MAX_SHIFTS, MIN_SHIFTS, 
                         END_DISTANCE_SUM, INIT_DISTANCE_SUM, EXPECTED_DISTANCE_SUM,
                         PENALTIES, MAX_PENALTIES, ROUNDS, MAX_ROUNDS,
-                        OBJECT_COUNT, PLAYERS]
+                        OBJECT_COUNT]
 
 # sub-metrics
 DISTANCE_SCORE = "Distance Score"
@@ -158,12 +157,13 @@ class MetricCalculator:
     def compute_coverage_score(self):
         id_set = set(self.ingredients[INIT_STATES]['state1'].keys())
         moves: List[Tuple[str, str]] = self.ingredients[MOVES]
-        players = self.ingredients[PLAYERS]
+        states = self.ingredients[INIT_STATES]
 
-        moved_obj_per_player = [set() for _ in players]
+        moved_obj_per_player = [set() for _ in states.keys()]
+        players_recorded = list(set(move[0] for move in moves))
         
         for move in moves: 
-            idx = players.index(move[0])
+            idx = players_recorded.index(move[0])
             moved_obj_per_player[idx].add(move[1])
 
         # add-one smoothing to avoid return 0

--- a/clean_up/resources/utils/metrics.py
+++ b/clean_up/resources/utils/metrics.py
@@ -19,11 +19,12 @@ MAX_PENALTIES = "Max Penalties"
 OBJECT_COUNT = "Object Count"
 ROUNDS = "Rounds"
 MAX_ROUNDS = "Max Rounds"
+PLAYERS = "Players"
 ingredients_registry = [MOVES, INIT_STATES, END_STATES,
                         SHIFTS, MAX_SHIFTS, MIN_SHIFTS, 
                         END_DISTANCE_SUM, INIT_DISTANCE_SUM, EXPECTED_DISTANCE_SUM,
                         PENALTIES, MAX_PENALTIES, ROUNDS, MAX_ROUNDS,
-                        OBJECT_COUNT]
+                        OBJECT_COUNT, PLAYERS]
 
 # sub-metrics
 DISTANCE_SCORE = "Distance Score"
@@ -63,6 +64,7 @@ class MetricPreparer:
             ROUNDS: lambda: gm.current_round,
             MAX_ROUNDS: gm.max_rounds,
             OBJECT_COUNT: len(player_1.grid.get_objects()),
+            PLAYERS: [player_1.name, player_2.name]
         }
 
         # validate(ingredients_registry, self.ingredients, self.__class__.__name__)
@@ -144,10 +146,10 @@ class MetricCalculator:
         min_shifts = self.ingredients[MIN_SHIFTS]
         shifts = self.ingredients[SHIFTS]
 
-        # when the players don't cover all the icons, return the best score 1
-        # we will capture this error with another metric, Coverage Score
+        # in this case consistency score doesn't make sense
+        # and will be taken out of bench_score
         if shifts < min_shifts: 
-            return 1
+            return None
 
         # add-one smoothing
         normalized = (shifts - min_shifts) / (max_shifts + 1 - min_shifts)
@@ -156,12 +158,12 @@ class MetricCalculator:
     def compute_coverage_score(self):
         id_set = set(self.ingredients[INIT_STATES]['state1'].keys())
         moves: List[Tuple[str, str]] = self.ingredients[MOVES]
+        players = self.ingredients[PLAYERS]
 
-        unique_players = list(set(move[0] for move in moves))
-        moved_obj_per_player = [set() for _ in unique_players]
+        moved_obj_per_player = [set() for _ in players]
         
         for move in moves: 
-            idx = unique_players.index(move[0])
+            idx = players.index(move[0])
             moved_obj_per_player[idx].add(move[1])
 
         # add-one smoothing to avoid return 0
@@ -185,6 +187,11 @@ class MetricCalculator:
         if sub_metrics[DISTANCE_SCORE] == 0:
             bench_score = 0
 
+        if self.ingredients[SHIFTS] < self.ingredients[MIN_SHIFTS]: 
+            # in this case, consistency score doesn't make sense,
+            # rm consistency score to prevent it artificially drives up the bench_score
+            del sub_metrics[CONSISTENCY_SCORE]
+            
         penalty_score = self.compute_penalty_score()
 
         # Take the harmonic mean of the sub-metrics, and multiply by the penalty score


### PR DESCRIPTION
The commit message for `fd909746d6a48273593812b2e1e2aa112fdb3474` should be "make metrics compatible with earlier interactions.json" 